### PR TITLE
fix(ui): align footer text and GitHub badge using flexbox

### DIFF
--- a/packages/web/src/style.css
+++ b/packages/web/src/style.css
@@ -716,11 +716,10 @@ input {
    12. FOOTER & RESPONSIVE
    ========================================= */
 .footer {
-position: fixed;
+    position: fixed;
     bottom: 10px;
     font-size: .75rem;
     color: var(--text-primary);
-    text-align: center;
     opacity: .85;
     width: fit-content;
     font-family: monospace;
@@ -729,10 +728,15 @@ position: fixed;
     padding: 5px 20px 10px;
     background-color: var(--bg);
     border-radius: 20px;
+    display: flex;
+    align-items: center;     
+    justify-content: center; 
+    gap: 6px;                
 }
 
 .footer svg {
-    margin: 5px 2px;
+    margin: 0;
+    display: block;          
 }
 
 .footer b {


### PR DESCRIPTION
Hi @mgks! 👋 

I really like this project and I'm very happy to make a contribution to it! I noticed a small visual alignment issue in the footer and put together this quick fix. 

## Description
This PR fixes the vertical alignment in the footer. Previously, the heart SVG icon and the text (`@mgks / fork:GitHubTree`) had mismatched baseline alignments, causing them to look slightly uneven. 

## Changes Made
- Updated the `.footer` class in `style.css` to use CSS Flexbox (`display: flex`, `align-items: center`).
- Added `gap: 6px` for clean, consistent spacing between the icon and text.
- Removed arbitrary margins on the SVG to allow Flexbox to handle the vertical centering perfectly.

## Visual Changes

### Before

<img width="373" height="68" alt="image" src="https://github.com/user-attachments/assets/61223a1e-409d-4032-80d3-a64a3c0adfff" />

### After


<img width="294" height="62" alt="image" src="https://github.com/user-attachments/assets/4422b566-d043-4eab-a367-359ce0e4e9f8" />


- [x] Verified alignment locally using the Vite dev server.


Let me know if you'd like me to change or adjust anything. Happy to contribute to GitHubTree! 






